### PR TITLE
Adds debian procps for pkill command which is used in entrypoint script

### DIFF
--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -33,9 +33,9 @@ RUN \
     && useradd --no-log-init -r -u $PUID -g $PGID factorio \
     && mkdir -p /usr/share/man/man1 \
     && apt-get -qqy update \
-    && apt-get -qqy install apt-utils procps \
+    && apt-get -qqy install apt-utils \
     && apt-get -qqy --no-install-recommends install \
-        ca-certificates curl gosu xz-utils > /dev/null \
+        ca-certificates curl gosu xz-utils procps > /dev/null \
     && curl -sSL https://www.factorio.com/get-download/$VERSION/headless/linux64 -o /tmp/factorio_headless_x64_$VERSION.tar.xz \
     && tar -xJf /tmp/factorio_headless_x64_$VERSION.tar.xz -C /opt \
     && bash -c 'mkdir -p {/factorio,/factorio/config,/factorio/mods,/factorio/saves,/factorio/scenarios}' \

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -33,7 +33,7 @@ RUN \
     && useradd --no-log-init -r -u $PUID -g $PGID factorio \
     && mkdir -p /usr/share/man/man1 \
     && apt-get -qqy update \
-    && apt-get -qqy install apt-utils \
+    && apt-get -qqy install apt-utils procps \
     && apt-get -qqy --no-install-recommends install \
         ca-certificates curl gosu xz-utils > /dev/null \
     && curl -sSL https://www.factorio.com/get-download/$VERSION/headless/linux64 -o /tmp/factorio_headless_x64_$VERSION.tar.xz \

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -33,9 +33,9 @@ RUN \
     && useradd --no-log-init -r -u $PUID -g $PGID factorio \
     && mkdir -p /usr/share/man/man1 \
     && apt-get -qqy update \
-    && apt-get -qqy install apt-utils procps \
+    && apt-get -qqy install apt-utils \
     && apt-get -qqy --no-install-recommends install \
-        ca-certificates curl gosu xz-utils > /dev/null \
+        ca-certificates curl gosu xz-utils procps > /dev/null \
     && curl -sSL https://www.factorio.com/get-download/$VERSION/headless/linux64 -o /tmp/factorio_headless_x64_$VERSION.tar.xz \
     && tar -xJf /tmp/factorio_headless_x64_$VERSION.tar.xz -C /opt \
     && bash -c 'mkdir -p {/factorio,/factorio/config,/factorio/mods,/factorio/saves,/factorio/scenarios}' \

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -33,7 +33,7 @@ RUN \
     && useradd --no-log-init -r -u $PUID -g $PGID factorio \
     && mkdir -p /usr/share/man/man1 \
     && apt-get -qqy update \
-    && apt-get -qqy install apt-utils \
+    && apt-get -qqy install apt-utils procps \
     && apt-get -qqy --no-install-recommends install \
         ca-certificates curl gosu xz-utils > /dev/null \
     && curl -sSL https://www.factorio.com/get-download/$VERSION/headless/linux64 -o /tmp/factorio_headless_x64_$VERSION.tar.xz \


### PR DESCRIPTION
Resolves issue in not saving game due to command not found.  Debian image does not have command `pkill` installed:

```factorio    | ++ echo '[2021-12-28 00:28:19,997] <docker-entrypoint> INFO - Exit signal received, commencing shutdown'
factorio    | ++ pkill -15 -f /opt/factorio/bin/x64/factorio
factorio    | /usr/local/bin/docker-entrypoint.sh: line 41: pkill: command not found```
